### PR TITLE
pip install 時に.py以外のファイルもパッケージに含める #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# IDE
-.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,24 @@
+{
+    "editor.tabSize": 4,
+    "python.linting.pycodestyleEnabled": false,
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.mypyEnabled": true,
+    "python.linting.lintOnSave": true,
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
+    "python.formatting.provider": "black",
+    "python.defaultInterpreterPath": ".venv/bin/python",
+    "python.autoComplete.extraPaths": [
+        ".venv/lib/python3.10/site-packages/"
+    ],
+    "python.linting.flake8Path": ".venv/bin/flake8",
+    "python.linting.mypyPath": ".venv/bin/mypy",
+    "python.formatting.blackPath": ".venv/bin/black",
+    "python.analysis.extraPaths": [
+        "~.venv/lib/python3.10/site-packages/"
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ $ exit
 $ pip install <path to pyproject.toml>
 $ today-google-calendar
 ```
+
+* pip install することでパッケージのバージョンが自動的に振られる

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ Source = "https://github.com/tomotaka-yamasaki/today-google-calendar"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+"hitokoto" = ["config/.env", "credentials/credentials.json"]
+
 [tool.setuptools.dynamic]
 version = {attr = "environments._version.version"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ Source = "https://github.com/tomotaka-yamasaki/today-google-calendar"
 [project.scripts]
 "today-google-calendar" = "src.today_google_calendar.today_google_calendar:main"
 
-[tool.setuptools]
-package-dir = {"" = "src"}
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools.dynamic]
 version = {attr = "environments._version.version"}


### PR DESCRIPTION
## 概要
* .env や credential.json はパッケージに含めないと動作しないが、その設定になっていなかった
* 一時的に pip install -e ./ でインストールしていたので、そのときのbuild cacheが残っていたため通常のpip installでも動作している場合があった

## 変更
* pyproject.tomlに含めるファイルを列挙

## 不具合修正
* pip installするとパッケージのコマンド実行時にimport errorを起こしていたので、scriptsパスを変更